### PR TITLE
Potential fix for code scanning alert no. 2: Stored cross-site scripting

### DIFF
--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { formatDate, getBlogPosts } from "app/lib/posts";
+import escape from "escape-html";
 
 export const metadata = {
   title: "Blog",
@@ -25,9 +26,9 @@ export default function BlogPosts() {
           })
           .map((post) => (
             <Link
-              key={post.slug}
+              key={escape(post.slug)}
               className="flex flex-col space-y-1 mb-4 transition-opacity duration-200 hover:opacity-80"
-              href={`/blog/${post.slug}`}
+              href={`/blog/${escape(post.slug)}`}
             >
               <div className="w-full flex flex-col sm:flex-row justify-between items-start sm:items-center space-y-1 sm:space-y-0 sm:space-x-2">
                 <p className="text-black dark:text-white tracking-tight">

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@types/react-dom": "18.3.0",
         "@vercel/analytics": "^1.3.1",
         "@vercel/speed-insights": "^1.0.12",
+        "escape-html": "^1.0.3",
         "feed": "^4.2.2",
         "geist": "1.3.1",
         "katex": "^0.16.21",
@@ -1107,6 +1108,11 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
     },
     "node_modules/estree-util-attach-comments": {
       "version": "3.0.0",
@@ -4939,6 +4945,11 @@
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
       "dev": true
+    },
+    "escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
     },
     "estree-util-attach-comments": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "rehype-katex": "^7.0.1",
     "remark-math": "^6.0.0",
     "sugar-high": "^0.7.0",
-    "typescript": "5.5.4"
+    "typescript": "5.5.4",
+    "escape-html": "^1.0.3"
   },
   "devDependencies": {
     "@tailwindcss/typography": "^0.5.14",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@vercel/speed-insights':
         specifier: ^1.0.12
         version: 1.0.12(next@14.2.23(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
+      escape-html:
+        specifier: ^1.0.3
+        version: 1.0.3
       feed:
         specifier: ^4.2.2
         version: 4.2.2
@@ -511,6 +514,9 @@ packages:
   escalade@3.1.2:
     resolution: {integrity: sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==}
     engines: {node: '>=6'}
+
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
 
   escape-string-regexp@1.0.5:
     resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
@@ -1699,6 +1705,8 @@ snapshots:
   entities@4.5.0: {}
 
   escalade@3.1.2: {}
+
+  escape-html@1.0.3: {}
 
   escape-string-regexp@1.0.5: {}
 


### PR DESCRIPTION
Potential fix for [https://github.com/fguendling/nextfolio-a-simple-next-js-portfolio/security/code-scanning/2](https://github.com/fguendling/nextfolio-a-simple-next-js-portfolio/security/code-scanning/2)

To fix the stored cross-site scripting vulnerability, we need to sanitize the `post.slug` value before using it in the `key` and `href` attributes of the `Link` component. We can use a library like `escape-html` to escape any potentially harmful characters in the `post.slug` value.

- Import the `escape-html` library in the `app/blog/page.tsx` file.
- Use the `escape` function from the `escape-html` library to sanitize the `post.slug` value before using it in the `key` and `href` attributes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
